### PR TITLE
1659: Add the Composition & Binary GET resources to the Allow-List of…

### DIFF
--- a/resources/hapi_page_url_allowed_queries.json
+++ b/resources/hapi_page_url_allowed_queries.json
@@ -7,6 +7,26 @@
       },
       "allowExtraParams": true,
       "allParamsRequired": true
+    },
+    {
+      "path": "/Composition/",
+      "pathVariables": "ANY_VALUE",
+      "methodType": "GET",
+      "queryParams": {
+
+      },
+      "allowExtraParams": true,
+      "allParamsRequired": false
+    },
+    {
+      "path": "/Binary/",
+      "pathVariables": "ANY_VALUE",
+      "methodType": "GET",
+      "queryParams": {
+
+      },
+      "allowExtraParams": true,
+      "allParamsRequired": false
     }
   ]
 }

--- a/server/src/main/java/com/google/fhir/proxy/AllowedQueriesChecker.java
+++ b/server/src/main/java/com/google/fhir/proxy/AllowedQueriesChecker.java
@@ -75,37 +75,78 @@ class AllowedQueriesChecker implements AccessChecker {
   }
 
   private boolean requestMatches(RequestDetailsReader requestDetails, AllowedQueryEntry entry) {
-    if (!entry.getPath().equals(requestDetails.getRequestPath())) {
-      return false;
-    }
-    Set<String> matchedQueryParams = Sets.newHashSet();
-    for (Entry<String, String> expectedParam : entry.getQueryParams().entrySet()) {
-      String[] actualQueryValue = requestDetails.getParameters().get(expectedParam.getKey());
-      if (actualQueryValue == null && entry.isAllParamsRequired()) {
-        // This allow-list entry does not match the query.
+    if (entry.getMethodType() != null && entry.getMethodType().equals(requestDetails.getRequestType().name()) && requestContainsPathVariables(requestDetails.getRequestPath())) {
+      String requestPath = getResourceFromCompleteRequestPath(requestDetails.getRequestPath());
+      if (!entry.getPath().equals(requestPath)) {
         return false;
       }
-      if (actualQueryValue == null) {
-        // Nothing else to do for this configured param as it is not present in the query.
-        continue;
-      }
-      if (!AllowedQueriesConfig.MATCHES_ANY_VALUE.equals(expectedParam.getValue())) {
-        if (actualQueryValue.length != 1) {
-          // We currently do not support multivalued query params in allow-lists.
-          return false;
-        }
-        if (!actualQueryValue[0].equals(expectedParam.getValue())) {
-          return false;
-        }
-      }
-      matchedQueryParams.add(expectedParam.getKey());
-    }
-    if (!entry.isAllowExtraParams()
-        && matchedQueryParams.size() != requestDetails.getParameters().size()) {
+    } else if (!entry.getPath().equals(requestDetails.getRequestPath())) {
       return false;
+    } else if (entry.getMethodType() != null && entry.getMethodType().equals(requestDetails.getRequestType().name())) {
+      Set<String> matchedQueryParams = Sets.newHashSet();
+      for (Entry<String, String> expectedParam : entry.getQueryParams()
+              .entrySet()) {
+        String[] actualQueryValue = requestDetails.getParameters()
+                .get(expectedParam.getKey());
+        if (actualQueryValue == null && entry.isAllParamsRequired()) {
+          // This allow-list entry does not match the query.
+          return false;
+        }
+        if (actualQueryValue == null) {
+          // Nothing else to do for this configured param as it is not present in the query.
+          continue;
+        }
+        if (!AllowedQueriesConfig.MATCHES_ANY_VALUE.equals(expectedParam.getValue())) {
+          if (actualQueryValue.length != 1) {
+            // We currently do not support multivalued query params in allow-lists.
+            return false;
+          }
+          if (!actualQueryValue[0].equals(expectedParam.getValue())) {
+            return false;
+          }
+        }
+        matchedQueryParams.add(expectedParam.getKey());
+      }
+      if (!entry.isAllowExtraParams() && matchedQueryParams.size() != requestDetails.getParameters()
+              .size()) {
+        return false;
+      }
+    } else {
+      logger.info("Allowed-queries entry {} matched query {}", entry, requestDetails.getCompleteUrl());
+      return true;
     }
-    logger.info(
-        "Allowed-queries entry {} matched query {}", entry, requestDetails.getCompleteUrl());
     return true;
+  }
+
+  private boolean requestContainsPathVariables(String completeRequestPath) {
+    String requestResourcePath = trimForwardSlashFromRequestPath(completeRequestPath);
+    if(requestResourcePath != null && requestResourcePath.startsWith("/")) {
+      requestResourcePath = requestResourcePath.substring(1);
+    }
+    if(requestResourcePath.contains("/")) {
+      return true;
+    }
+    return false;
+  }
+
+  private String getResourceFromCompleteRequestPath(String completeRequestPath) {
+   String requestResourcePath = trimForwardSlashFromRequestPath(completeRequestPath);
+    if(requestResourcePath.contains("/")) {
+
+      int pathVarIndex = requestResourcePath.indexOf("/");
+      String pathVar = requestResourcePath.substring(pathVarIndex+1);
+      String requestPath = requestResourcePath.substring(0,pathVarIndex+1);
+      requestPath = "/" + requestPath;
+      return requestPath;
+    }
+    return requestResourcePath;
+  }
+
+  private String trimForwardSlashFromRequestPath(String completeRequestPath) {
+    String requestResourcePath = completeRequestPath;
+    if(completeRequestPath.startsWith("/")) {
+      requestResourcePath = completeRequestPath.substring(1);
+    }
+    return requestResourcePath;
   }
 }

--- a/server/src/main/java/com/google/fhir/proxy/AllowedQueriesConfig.java
+++ b/server/src/main/java/com/google/fhir/proxy/AllowedQueriesConfig.java
@@ -32,6 +32,9 @@ class AllowedQueriesConfig {
   @Getter
   public static class AllowedQueryEntry {
     private String path;
+    private String pathVariables;
+
+    private String methodType;
     private Map<String, String> queryParams;
     // If true, this means other parameters not listed in `queryParams` are allowed too.
     private boolean allowExtraParams;
@@ -43,6 +46,8 @@ class AllowedQueriesConfig {
       String builder =
           "path="
               + path
+              + pathVariables
+              + methodType
               + " queryParams="
               + Arrays.toString(queryParams.entrySet().toArray())
               + " allowExtraParams="

--- a/server/src/main/java/com/google/fhir/proxy/BearerAuthorizationInterceptor.java
+++ b/server/src/main/java/com/google/fhir/proxy/BearerAuthorizationInterceptor.java
@@ -209,6 +209,12 @@ public class BearerAuthorizationInterceptor {
       return CapabilityPostProcessor.getInstance(server.getFhirContext());
     }
     // Check the Bearer token to be a valid JWT with required claims.
+
+    RequestDetailsReader requestDetailsReader = new RequestDetailsToReader(requestDetails);
+    AccessDecision allowedQueriesDecision = allowedQueriesChecker.checkAccess(requestDetailsReader);
+    if (allowedQueriesDecision.canAccess()) {
+      return allowedQueriesDecision;
+    }
     String authHeader = requestDetails.getHeader("Authorization");
     if (authHeader == null) {
       ExceptionUtil.throwRuntimeExceptionAndLog(
@@ -216,11 +222,6 @@ public class BearerAuthorizationInterceptor {
     }
     DecodedJWT decodedJwt = decodeAndVerifyBearerToken(authHeader);
     FhirContext fhirContext = server.getFhirContext();
-    RequestDetailsReader requestDetailsReader = new RequestDetailsToReader(requestDetails);
-    AccessDecision allowedQueriesDecision = allowedQueriesChecker.checkAccess(requestDetailsReader);
-    if (allowedQueriesDecision.canAccess()) {
-      return allowedQueriesDecision;
-    }
     PatientFinderImp patientFinder = PatientFinderImp.getInstance(fhirContext);
     AccessChecker accessChecker =
         accessFactory.create(decodedJwt, fhirClient, fhirContext, patientFinder);

--- a/server/src/test/java/com/google/fhir/proxy/AllowedQueriesCheckerTest.java
+++ b/server/src/test/java/com/google/fhir/proxy/AllowedQueriesCheckerTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
 
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import com.google.fhir.proxy.interfaces.RequestDetailsReader;
@@ -40,6 +41,7 @@ public class AllowedQueriesCheckerTest {
   public void validGetPagesQuery() throws IOException {
     // Query: GET ?_getpages=A_PAGE_ID
     when(requestMock.getRequestPath()).thenReturn("");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     Map<String, String[]> params = Maps.newHashMap();
     params.put("_getpages", new String[] {"A_PAGE_ID"});
     when(requestMock.getParameters()).thenReturn(params);
@@ -52,6 +54,7 @@ public class AllowedQueriesCheckerTest {
   public void validGetPagesQueryExtraValue() throws IOException {
     // Query: GET ?_getpages=A_PAGE_ID,A_SECOND_ID
     when(requestMock.getRequestPath()).thenReturn("");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     Map<String, String[]> params = Maps.newHashMap();
     params.put("_getpages", new String[] {"A_PAGE_ID", "A_SECOND_ID"});
     when(requestMock.getParameters()).thenReturn(params);
@@ -64,6 +67,7 @@ public class AllowedQueriesCheckerTest {
   public void validGetPagesQueryExtraParam() throws IOException {
     // Query: GET ?_getpages=A_PAGE_ID&another_param=SOMETHING
     when(requestMock.getRequestPath()).thenReturn("");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     Map<String, String[]> params = Maps.newHashMap();
     params.put("_getpages", new String[] {"A_PAGE_ID"});
     params.put("another_param", new String[] {"SOMETHING"});
@@ -77,6 +81,7 @@ public class AllowedQueriesCheckerTest {
   public void noMatchForObservationQuery() throws IOException {
     // Query: GET /Observation?_getpages=A_PAGE_ID
     when(requestMock.getRequestPath()).thenReturn("/Observation");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     URL configFileUrl = Resources.getResource("hapi_page_url_allowed_queries.json");
     AllowedQueriesChecker testInstance = new AllowedQueriesChecker(configFileUrl.getPath());
     assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(false));
@@ -98,6 +103,7 @@ public class AllowedQueriesCheckerTest {
   public void denyGetPagesQueryExtraParam() throws IOException {
     // Query: GET ?_getpages=A_PAGE_ID&another_param=SOMETHING
     when(requestMock.getRequestPath()).thenReturn("");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     Map<String, String[]> params = Maps.newHashMap();
     params.put("_getpages", new String[] {"A_PAGE_ID"});
     params.put("another_param", new String[] {"SOMETHING"});
@@ -111,6 +117,7 @@ public class AllowedQueriesCheckerTest {
   public void denyQueryWithoutRequiredParam() throws IOException {
     // Query: GET ?another_param=SOMETHING
     when(requestMock.getRequestPath()).thenReturn("");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     Map<String, String[]> params = Maps.newHashMap();
     params.put("another_param", new String[] {"SOMETHING"});
     URL configFileUrl = Resources.getResource("hapi_page_url_allowed_queries.json");

--- a/server/src/test/resources/allowed_queries_with_no_extra_params.json
+++ b/server/src/test/resources/allowed_queries_with_no_extra_params.json
@@ -2,6 +2,7 @@
   "entries": [
     {
       "path": "",
+      "methodType": "GET",
       "queryParams": {
         "_getpages": "ANY_VALUE"
       },

--- a/server/src/test/resources/hapi_page_url_allowed_queries.json
+++ b/server/src/test/resources/hapi_page_url_allowed_queries.json
@@ -2,6 +2,7 @@
   "entries": [
     {
       "path": "",
+      "methodType": "GET",
       "queryParams": {
         "_getpages": "ANY_VALUE"
       },


### PR DESCRIPTION
… the Proxy server.

#Resolves https://github.com/opensrp/fhircore/issues/1659
The PR consists of code amendments in the Allowed Queries Checker implementation:

- Modified the flow to allow access via the Allowed Queries Checker without a token. This would allow the exemption of end-points defined under the [hapi_page_url_allowed_queries.json](https://github.com/opensrp/fhir-access-proxy/blob/main/resources/hapi_page_url_allowed_queries.json) file for both authentication and authorization workflows.
- Introduced support of Path Variables.
- Introduced support of HTTP method type.
- This does not verify the authenticity of the token if provided. **_//Add this in the TO-DO_** 